### PR TITLE
32bit StMM with OP-TEE/RPMB (take 2)

### DIFF
--- a/Drivers/OpTee/OpteeRpmbPkg/OpTeeRpmbFvb.c
+++ b/Drivers/OpTee/OpteeRpmbPkg/OpTeeRpmbFvb.c
@@ -68,7 +68,7 @@ ReadWriteRpmb (
 
   ZeroMem (&SvcArgs, sizeof (SvcArgs));
 
-  SvcArgs.Arg0 = ARM_SVC_ID_FFA_MSG_SEND_DIRECT_REQ_AARCH64;
+  SvcArgs.Arg0 = ARM_SVC_ID_FFA_MSG_SEND_DIRECT_REQ;
   SvcArgs.Arg1 = mStorageId;
   SvcArgs.Arg2 = 0;
   SvcArgs.Arg3 = SvcAct;

--- a/Drivers/OpTee/OpteeRpmbPkg/OpTeeRpmbFvb.h
+++ b/Drivers/OpTee/OpteeRpmbPkg/OpTeeRpmbFvb.h
@@ -13,8 +13,20 @@
  contract between OP-TEE and EDK2.
  For more details check core/arch/arm/include/kernel/stmm_sp.h in OP-TEE
 **/
-#define SP_SVC_RPMB_READ                0xC4000066
-#define SP_SVC_RPMB_WRITE               0xC4000067
+#define SP_SVC_RPMB_READ_AARCH64        0xC4000066
+#define SP_SVC_RPMB_WRITE_AARCH64       0xC4000067
+
+#define SP_SVC_RPMB_READ_AARCH32        0x84000066
+#define SP_SVC_RPMB_WRITE_AARCH32       0x84000067
+
+#ifdef MDE_CPU_AARCH64
+#define SP_SVC_RPMB_READ                SP_SVC_RPMB_READ_AARCH64
+#define SP_SVC_RPMB_WRITE               SP_SVC_RPMB_WRITE_AARCH64
+#endif
+#ifdef MDE_CPU_ARM
+#define SP_SVC_RPMB_READ                SP_SVC_RPMB_READ_AARCH32
+#define SP_SVC_RPMB_WRITE               SP_SVC_RPMB_WRITE_AARCH32
+#endif
 
 #define FLASH_SIGNATURE            SIGNATURE_32 ('r', 'p', 'm', 'b')
 #define INSTANCE_FROM_FVB_THIS(a)  CR (a, MEM_INSTANCE, FvbProtocol, \

--- a/Platform/ARM/SgiPkg/PlatformStandaloneMm.dsc
+++ b/Platform/ARM/SgiPkg/PlatformStandaloneMm.dsc
@@ -122,7 +122,7 @@
   StandaloneMmPkg/Core/StandaloneMmCore.inf
 
 [Components.AARCH64]
-  StandaloneMmPkg/Drivers/StandaloneMmCpu/AArch64/StandaloneMmCpu.inf
+  StandaloneMmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
 
 ###################################################################################################
 #

--- a/Platform/ARM/SgiPkg/PlatformStandaloneMm.fdf
+++ b/Platform/ARM/SgiPkg/PlatformStandaloneMm.fdf
@@ -49,7 +49,7 @@ READ_LOCK_CAP      = TRUE
 READ_LOCK_STATUS   = TRUE
 
   INF StandaloneMmPkg/Core/StandaloneMmCore.inf
-  INF StandaloneMmPkg/Drivers/StandaloneMmCpu/AArch64/StandaloneMmCpu.inf
+  INF StandaloneMmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
 
 ################################################################################
 #

--- a/Platform/Socionext/DeveloperBox/DeveloperBoxMm.dsc
+++ b/Platform/Socionext/DeveloperBox/DeveloperBoxMm.dsc
@@ -80,7 +80,7 @@
       gEfiMdePkgTokenSpaceGuid.PcdMaximumGuidedExtractHandler|0x2
   }
 
-  StandaloneMmPkg/Drivers/StandaloneMmCpu/AArch64/StandaloneMmCpu.inf
+  StandaloneMmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
   Silicon/Socionext/SynQuacer/Drivers/Fip006Dxe/Fip006StandaloneMm.inf
   MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf {

--- a/Platform/Socionext/DeveloperBox/DeveloperBoxMm.fdf
+++ b/Platform/Socionext/DeveloperBox/DeveloperBoxMm.fdf
@@ -111,7 +111,7 @@ READ_LOCK_STATUS   = TRUE
   INF Silicon/Socionext/SynQuacer/Drivers/Fip006Dxe/Fip006StandaloneMm.inf
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
-  INF StandaloneMmPkg/Drivers/StandaloneMmCpu/AArch64/StandaloneMmCpu.inf
+  INF StandaloneMmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
 
 ################################################################################
 #

--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
@@ -133,7 +133,7 @@
   #
   Drivers/OpTee/OpteeRpmbPkg/OpTeeRpmbFv.inf
   StandaloneMmPkg/Core/StandaloneMmCore.inf
-  StandaloneMmPkg/Drivers/StandaloneMmCpu/AArch64/StandaloneMmCpu.inf
+  StandaloneMmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
   MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf {
     <LibraryClasses>
       NULL|Drivers/OpTee/OpteeRpmbPkg/FixupPcd.inf

--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.dsc
@@ -16,11 +16,13 @@
   PLATFORM_VERSION               = 1.0
   DSC_SPECIFICATION              = 0x0001001C
   OUTPUT_DIRECTORY               = Build/$(PLATFORM_NAME)
-  SUPPORTED_ARCHITECTURES        = AARCH64
+  SUPPORTED_ARCHITECTURES        = ARM|AARCH64
   BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER               = DEFAULT
   FLASH_DEFINITION               = Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.fdf
   DEFINE DEBUG_MESSAGE           = TRUE
+
+!include MdePkg/MdeLibs.dsc.inc
 
 ################################################################################
 #
@@ -39,6 +41,7 @@
   FvLib|StandaloneMmPkg/Library/FvLib/FvLib.inf
   HobLib|StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
   MemLib|StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
   MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
@@ -67,6 +70,9 @@
   # NULL means link this library into all ARM images.
   #
   NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+
+[LibraryClasses.ARM]
+  ArmSoftFloatLib|ArmPkg/Library/ArmSoftFloatLib/ArmSoftFloatLib.inf
 
 [LibraryClasses.common.MM_STANDALONE]
   HobLib|StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf
@@ -160,3 +166,7 @@
 [BuildOptions.AARCH64]
 GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000 -march=armv8-a+nofp
 GCC:*_*_*_CC_FLAGS = -mstrict-align
+
+[BuildOptions.ARM]
+GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000 -march=armv7-a
+GCC:*_*_*_CC_FLAGS = -fno-stack-protector

--- a/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.fdf
+++ b/Platform/StandaloneMm/PlatformStandaloneMmPkg/PlatformStandaloneMmRpmb.fdf
@@ -68,7 +68,8 @@ READ_LOCK_STATUS   = TRUE
   INF Drivers/OpTee/OpteeRpmbPkg/OpTeeRpmbFv.inf
   INF MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
-  INF StandaloneMmPkg/Drivers/StandaloneMmCpu/AArch64/StandaloneMmCpu.inf
+  INF StandaloneMmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf
+
 ################################################################################
 #
 # Rules are use with the [FV] section's module INF type to define


### PR DESCRIPTION
Supersedes #1. Arm and RPMB changes have been merged, remains the 32bit port to post.

1st commit in this series synchronizes edk2-platforms with changes from edk2 (see P-R #xxx) in the source tree paths, removing Aarch64/ subdirectories or renaming it arm/ since applicable to both 32bit/Aarch32 adn Aarch64.